### PR TITLE
Fix grunt watch scripts task

### DIFF
--- a/grunt/watch.js
+++ b/grunt/watch.js
@@ -7,7 +7,7 @@ module.exports = {
     scripts:
     {
         files: "<%= concat.scripts.src %>",
-        tasks: [ "envDev", "concat:scripts", "replace" ]
+        tasks: [ "envDev", "copy:scripts", "concat:scripts", "replace" ]
     },
     styles:
     {


### PR DESCRIPTION
Because we're using includeSource in dev, the script modules files need to be copied here to update when making changes.

@jrit 
