### PR TITLE
Add babel to buildcore and watch task

### DIFF
--- a/grunt/aliases.yaml
+++ b/grunt/aliases.yaml
@@ -7,6 +7,7 @@ buildcore:
   - concat:scripts
   - concat:angular
   - concat:components
+  - babel
   - less
   - postcss
   - copy
@@ -64,7 +65,6 @@ deploy:
   - clean
   - buildcore
   - clean:modules
-  - babel
   - uglify
   - concat:dist
   - rev

--- a/grunt/watch.js
+++ b/grunt/watch.js
@@ -18,7 +18,7 @@ module.exports = {
     scripts:
     {
         files: "<%= concat.scripts.src %>",
-        tasks: [ "envLocal", "newer:jshint:dev", "concat:scripts", "replace" ]
+        tasks: [ "envLocal", "newer:jshint:dev", "concat:scripts", "babel", "replace" ]
     },
     styles:
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dominatr-grunt",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Build all the things!",
   "scripts": {
     "test": ""


### PR DESCRIPTION
Found tests are failing on browsers that do not support ES6 features because scripts were not being run through babel prior to testing. Arrow functions for example are only supported in Chrome in v45.

@vokal/web 
