### PR TITLE
Remove atBegin from watch options

### DIFF
--- a/grunt/watch.js
+++ b/grunt/watch.js
@@ -1,7 +1,6 @@
 module.exports = {
     options:
     {
-        atBegin: true,
         livereload: true,
         event: [ "changed", "added", "deleted" ]
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dominatr-grunt",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Build all the things!",
   "scripts": {
     "test": ""


### PR DESCRIPTION
Swapping projects usually means running the following: `npm start` and in another tab `grunt watch`.

The `watch` task is rebuilds almost everything, it's not necessary for it's use case. This also saves ~30 seconds when starting the `watch` task.

@vokal/web 