### PR TITLE
Watch performance boost

### DIFF
--- a/grunt/browserify.js
+++ b/grunt/browserify.js
@@ -52,6 +52,9 @@ module.exports = function ( grunt )
             }
         },
         build: {
+            options: {
+                watch: true
+            },
             src: files,
             dest: "build/dist.js"
         },

--- a/grunt/watch.js
+++ b/grunt/watch.js
@@ -2,7 +2,8 @@
 
 module.exports = {
     options: {
-        event: [ "changed", "added", "deleted" ]
+        event: [ "changed", "added", "deleted" ],
+        spawn: false
     },
     index: {
         files: "<%= copy.index.src %>",
@@ -35,9 +36,7 @@ module.exports = {
         tasks: [ "svg_sprite" ]
     },
     livereload: {
-        options: {
-            "livereload": true
-        },
+        options: { livereload: true },
         files: [ "build/**/*.*" ]
     }
 };

--- a/grunt/watch.js
+++ b/grunt/watch.js
@@ -8,14 +8,6 @@ module.exports = {
         files: "<%= copy.index.src %>",
         tasks: [ "copy:index" ]
     },
-    browserify: {
-        files: [
-            "build/templates.js",
-            "source/modules/**/*.js",
-            "!source/modules/*/tests/**/*.*"
-        ],
-        tasks: [ "browserify:build" ]
-    },
     jshint: {
         files: "<%= jshint.dev.src %>",
         tasks: [ "newer:jshint:dev" ]


### PR DESCRIPTION
Removes loading of all grunt tasks in `grunt watch`. This is a situation due to how `load-grunt-config` works. Usual response times for almost all tasks was 12.5+ seconds. `.js` and `.html` changes with livereload have been dropped to ~1 second.

There's an issue with the `index.html` file not triggering the reload even though the copy task completes. Will add an issue to track down that problem separately. The bonuses here outweigh having to refresh when changing just that file.

@vokal/web 