### PR TITLE
remove version as an argument

### DIFF
--- a/grunt/notification_slack.js
+++ b/grunt/notification_slack.js
@@ -6,7 +6,7 @@ module.exports = function ( grunt )
 {
     var envConfig = grunt.config( "env" );
     var slackApiToken = grunt.config( "slackApiToken" );
-    var deployVersion = grunt.config( "version" );
+    var commit = grunt.config( "commit" );
     var pkg = grunt.file.readJSON( "package.json" );
     var pkgVersion = pkg.version || "";
     var pkgName = pkg.name || "App";
@@ -28,7 +28,7 @@ module.exports = function ( grunt )
         var slacker = new Slack( slackApiToken );
 
         slacker.api( "chat.postMessage", {
-            text: pkgName + " build " + pkgVersion + " @" + deployVersion + " for " + host
+            text: pkgName + " build " + pkgVersion + " @" + commit + " for " + host
                 + " should be available in about 10 minutes.",
             channel: slackChannel,
             username: "Release Bot"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dominatr-grunt",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "description": "Build all the things!",
   "scripts": {
     "test": ""


### PR DESCRIPTION
`grunt --version` causes it to print the version and halt execution, so not what we wanted :smile: 

@dmaloneycalu 