### PR TITLE
Update grunt-contrib-jshint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Changelog
 
 
+#### 6.1.3 Update Grunt JSHint version
+
+- Updated to support JSHint ~2.9.0, most notably the `esversion` property
+
 #### 6.1.2 Move PostCSS to build
 
 - Local files were not functionally equivalent to deployed code which made testing problematic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dominatr-grunt",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "description": "Build all the things!",
   "scripts": {
     "test": ""
@@ -29,7 +29,7 @@
     "grunt-contrib-connect": "^0.11.2",
     "grunt-contrib-copy": "^0.8.2",
     "grunt-contrib-imagemin": "^1.0.0",
-    "grunt-contrib-jshint": "^0.11.3",
+    "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-less": "^1.1.0",
     "grunt-contrib-uglify": "^0.10.1",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
@jrit @dmaloneycalu 

As noted in https://github.com/vokal/dominatr/pull/114, need updated version to support latest jshint changes in dominatr